### PR TITLE
グラフのnameに都道府県名を設定

### DIFF
--- a/src/components/Chart.tsx
+++ b/src/components/Chart.tsx
@@ -18,15 +18,19 @@ export const Chart: FC<Props> = ({ prefPopulations }) => {
 
   // 初期値を空にして、型をtypesに書く
   let series: Series[] = []
+  console.log('pref!', prefPopulations)
+
   if (prefPopulations[0]) {
-    yearArr = prefPopulations[0].map((v, i) => {
+    // yearArr = prefPopulations[0].map((v, i) => {
+    yearArr = prefPopulations[0].data.map((v, i) => {
       return v.year
     })
     prefPopulations.map((v, i) => {
       series.push({
         // ["東東","神奈川","鳥取"][i]みたいに取りたい
-        name: `都道府県名${i}`,
-        data: v.map((v2, i2) => {
+        name: v.prefName,
+        // data: v.map((v2, i2) => {
+        data: v.data.map((v2, i2) => {
           return v2.value
         }),
         pointPlacement: 'on',

--- a/src/components/Chart.tsx
+++ b/src/components/Chart.tsx
@@ -10,40 +10,23 @@ interface Props {
 }
 
 export const Chart: FC<Props> = ({ prefPopulations }) => {
-  let yearArr = []
-  // const yearArr = [
-  //   1960, 1965, 1970, 1975, 1980, 1985, 1990, 1995, 2000, 2005, 2010, 2015,
-  //   2020, 2025, 2030, 2035, 2040, 2045,
-  // ]
-
-  // 初期値を空にして、型をtypesに書く
   let series: Series[] = []
-  console.log('pref!', prefPopulations)
+  let yearArr: number[] = []
 
+  // 都道府県を選択していたらグラフを生成
   if (prefPopulations[0]) {
-    // yearArr = prefPopulations[0].map((v, i) => {
-    yearArr = prefPopulations[0].data.map((v, i) => {
+    yearArr = prefPopulations[0].data.map((v) => {
       return v.year
     })
-    prefPopulations.map((v, i) => {
+    prefPopulations.map((prefPopulation, i) => {
       series.push({
-        // ["東東","神奈川","鳥取"][i]みたいに取りたい
-        name: v.prefName,
-        // data: v.map((v2, i2) => {
-        data: v.data.map((v2, i2) => {
-          return v2.value
+        name: prefPopulation.prefName,
+        data: prefPopulation.data.map((values) => {
+          return values.value
         }),
         pointPlacement: 'on',
       })
     })
-
-    // const arrr = prefPopulations.map((a, i) => {
-    //   name: "都道府県名",
-    //   data: a.map((v, i) => {
-    //     return v.value
-    //   }),
-    //   pointPlacement: "on"
-    // })
   }
 
   if (typeof Highcharts === 'object') {

--- a/src/components/Chart.tsx
+++ b/src/components/Chart.tsx
@@ -1,39 +1,30 @@
 import { FC } from 'react'
-import { PrefPopulation } from '../types/prefPopulation'
+import { PrefPopulations } from '../types/prefPopulations'
 import Highcharts from 'highcharts'
 import HighchartsExporting from 'highcharts/modules/exporting'
 import HighchartsReact from 'highcharts-react-official'
+import { Series } from '../types/series.'
 
 interface Props {
-  prefPopulation: PrefPopulation[]
+  prefPopulations: PrefPopulations[]
 }
 
-export const Chart: FC<Props> = ({ prefPopulation }) => {
+export const Chart: FC<Props> = ({ prefPopulations }) => {
   let yearArr = []
-  let series = [{}]
-  if (prefPopulation[0]) {
-    yearArr = prefPopulation[0].map((v, i) => {
+  // const yearArr = [
+  //   1960, 1965, 1970, 1975, 1980, 1985, 1990, 1995, 2000, 2005, 2010, 2015,
+  //   2020, 2025, 2030, 2035, 2040, 2045,
+  // ]
+
+  // 初期値を空にして、型をtypesに書く
+  let series: Series[] = []
+  if (prefPopulations[0]) {
+    yearArr = prefPopulations[0].map((v, i) => {
       return v.year
     })
-    // const valueArr = {
-    //   name: '都道府県名',
-    //   data: prefPopulation[0].map((v, i) => {
-    //     return v.value
-    //   }),
-    //   pointPlacement: 'on',
-    // }
-
-    // const dataArr = [prefPopulation.map((v, i) => {
-    //   {
-    //     name: '都道府県名',
-    //     data: prefPopulation[0].map((v2, i2) => {
-    //       return v2.value
-    //     }),
-    //     pointPlacement: 'on',
-    //   },
-    // })]
-    prefPopulation.map((v, i) => {
+    prefPopulations.map((v, i) => {
       series.push({
+        // ["東東","神奈川","鳥取"][i]みたいに取りたい
         name: '都道府県名',
         data: v.map((v2, i2) => {
           return v2.value
@@ -43,7 +34,7 @@ export const Chart: FC<Props> = ({ prefPopulation }) => {
     })
 
     console.log(series)
-    // const arrr = prefPopulation.map((a, i) => {
+    // const arrr = prefPopulations.map((a, i) => {
     //   name: "都道府県名",
     //   data: a.map((v, i) => {
     //     return v.value
@@ -51,11 +42,6 @@ export const Chart: FC<Props> = ({ prefPopulation }) => {
     //   pointPlacement: "on"
     // })
   }
-  // const yearArr = [
-  //   1960, 1965, 1970, 1975, 1980, 1985, 1990, 1995, 2000, 2005, 2010, 2015,
-  //   2020, 2025, 2030, 2035, 2040, 2045,
-  // ]
-  // series name: 都道府県名:string、data: 人口数:string[]
 
   if (typeof Highcharts === 'object') {
     HighchartsExporting(Highcharts)
@@ -125,22 +111,10 @@ export const Chart: FC<Props> = ({ prefPopulation }) => {
       ],
     },
   }
-  console.log(prefPopulation)
+  console.log(prefPopulations)
   return (
     <>
       <HighchartsReact highcharts={Highcharts} options={options} />
-      <ul className='flex gap-4'>
-        {prefPopulation &&
-          prefPopulation.map((v, i) => (
-            <div key={i}>
-              {v.map((value, index) => (
-                <li key={index}>
-                  {value.year}: {value.value}
-                </li>
-              ))}
-            </div>
-          ))}
-      </ul>
     </>
   )
 }

--- a/src/components/Chart.tsx
+++ b/src/components/Chart.tsx
@@ -25,7 +25,7 @@ export const Chart: FC<Props> = ({ prefPopulations }) => {
     prefPopulations.map((v, i) => {
       series.push({
         // ["東東","神奈川","鳥取"][i]みたいに取りたい
-        name: '都道府県名',
+        name: `都道府県名${i}`,
         data: v.map((v2, i2) => {
           return v2.value
         }),
@@ -33,7 +33,6 @@ export const Chart: FC<Props> = ({ prefPopulations }) => {
       })
     })
 
-    console.log(series)
     // const arrr = prefPopulations.map((a, i) => {
     //   name: "都道府県名",
     //   data: a.map((v, i) => {
@@ -111,7 +110,6 @@ export const Chart: FC<Props> = ({ prefPopulations }) => {
       ],
     },
   }
-  console.log(prefPopulations)
   return (
     <>
       <HighchartsReact highcharts={Highcharts} options={options} />

--- a/src/components/PrefectureList.tsx
+++ b/src/components/PrefectureList.tsx
@@ -1,17 +1,20 @@
 import { Dispatch, FC, SetStateAction, useEffect, useState, VFC } from 'react'
+import { ChoosePrefs } from '../types/choosePrefs'
 import { Prefectures } from '../types/prefectures'
 import { PrefPopulations } from '../types/prefPopulations'
 
 interface Props {
-  choosePref: string[]
-  setChoosePref: Dispatch<SetStateAction<string[]>>
+  // choosePrefs: string[]
+  // setChoosePrefs: Dispatch<SetStateAction<string[]>>
+  choosePrefs: ChoosePrefs[]
+  setChoosePrefs: Dispatch<SetStateAction<ChoosePrefs[]>>
   prefPopulations: PrefPopulations[]
   setPrefPopulations: Dispatch<SetStateAction<PrefPopulations[]>>
 }
 
 export const PrefectureList: FC<Props> = ({
-  choosePref,
-  setChoosePref,
+  choosePrefs,
+  setChoosePrefs,
   prefPopulations,
   setPrefPopulations,
 }) => {
@@ -29,9 +32,9 @@ export const PrefectureList: FC<Props> = ({
   }, [])
 
   // 都道府県のデータを取得
-  const addPrefData = (pref_id: string) => {
+  const addPrefData = (prefCode: string) => {
     fetch(
-      `https://opendata.resas-portal.go.jp/api/v1/population/composition/perYear?cityCode=-&prefCode=${pref_id}`,
+      `https://opendata.resas-portal.go.jp/api/v1/population/composition/perYear?cityCode=-&prefCode=${prefCode}`,
       {
         headers: {
           'X-API-KEY': String(process.env.NEXT_PUBLIC_RESAS_APIKEY),
@@ -51,20 +54,30 @@ export const PrefectureList: FC<Props> = ({
     setPrefPopulations([...newData])
   }
 
-  const changePrefectures = (pref_id: string) => {
+  const changePrefectures = (prefCode: string, prefName: string) => {
+    let flug = true
     // チェックが外れる時
-    if (choosePref.includes(pref_id)) {
-      const deleteIndex = choosePref.indexOf(pref_id)
-      const newArr = choosePref
-      newArr.splice(deleteIndex, 1)
-      setChoosePref(newArr)
-      deletePrefData(deleteIndex)
-      return
+    choosePrefs.forEach((object, index) => {
+      if (object.prefCode === prefCode && flug) {
+        const deleteIndex = index
+        const newArr = choosePrefs
+        newArr.splice(deleteIndex, 1)
+        setChoosePrefs(newArr)
+        deletePrefData(deleteIndex)
+        flug = false
+      }
+    })
+    if (flug) {
+      setChoosePrefs([
+        ...choosePrefs,
+        { prefCode: prefCode, prefName: prefName },
+      ])
+      addPrefData(prefCode)
     }
-    setChoosePref([...choosePref, pref_id])
-    addPrefData(pref_id)
   }
 
+  console.log('chooseP', choosePrefs)
+  console.log('prefP', prefPopulations)
   return (
     <div>
       <ul className='flex flex-wrap gap-4'>
@@ -73,9 +86,9 @@ export const PrefectureList: FC<Props> = ({
             <li
               className='flex items-center'
               key={i}
-              onChange={() => changePrefectures(String(v.prefCode))}
+              onChange={() => changePrefectures(String(v.prefCode), v.prefName)}
             >
-              <input type='checkbox' name='' id={v.prefName} />
+              <input type='checkbox' id={v.prefName} />
               <label htmlFor={v.prefName}>
                 {v.prefCode}. {v.prefName}
               </label>

--- a/src/components/PrefectureList.tsx
+++ b/src/components/PrefectureList.tsx
@@ -1,19 +1,19 @@
 import { Dispatch, FC, SetStateAction, useEffect, useState, VFC } from 'react'
 import { Prefectures } from '../types/prefectures'
-import { PrefPopulation } from '../types/prefPopulation'
+import { PrefPopulations } from '../types/prefPopulations'
 
 interface Props {
   choosePref: string[]
   setChoosePref: Dispatch<SetStateAction<string[]>>
-  prefPopulation: PrefPopulation[]
-  setPrefPopulation: Dispatch<SetStateAction<PrefPopulation[]>>
+  prefPopulations: PrefPopulations[]
+  setPrefPopulations: Dispatch<SetStateAction<PrefPopulations[]>>
 }
 
 export const PrefectureList: FC<Props> = ({
   choosePref,
   setChoosePref,
-  prefPopulation,
-  setPrefPopulation,
+  prefPopulations,
+  setPrefPopulations,
 }) => {
   const [prefectures, setPrefectures] = useState<Prefectures[]>([])
 
@@ -40,15 +40,15 @@ export const PrefectureList: FC<Props> = ({
     )
       .then((res) => res.json())
       .then((res) => {
-        setPrefPopulation([...prefPopulation, res.result.data[0].data])
+        setPrefPopulations([...prefPopulations, res.result.data[0].data])
       })
   }
 
   // 指定された都道府県のデータを削除
   const deletePrefData = (deleteIndex: number) => {
-    const newData: PrefPopulation[] = prefPopulation
+    const newData: PrefPopulations[] = prefPopulations
     newData.splice(deleteIndex, 1)
-    setPrefPopulation([...newData])
+    setPrefPopulations([...newData])
   }
 
   const changePrefectures = (pref_id: string) => {

--- a/src/components/PrefectureList.tsx
+++ b/src/components/PrefectureList.tsx
@@ -77,8 +77,6 @@ export const PrefectureList: FC<Props> = ({
     }
   }
 
-  console.log('chooseP', choosePrefs)
-  console.log('prefP', prefPopulations)
   return (
     <div>
       <ul className='flex flex-wrap gap-4'>

--- a/src/components/PrefectureList.tsx
+++ b/src/components/PrefectureList.tsx
@@ -1,34 +1,13 @@
-import { Dispatch, FC, SetStateAction, useEffect, useState, VFC } from 'react'
+import { Dispatch, FC, SetStateAction, useEffect, useState } from 'react'
 import { ChoosePrefs } from '../types/choosePrefs'
 import { Prefectures } from '../types/prefectures'
-import { Prefdata, PrefPopulations } from '../types/prefPopulations'
+import { PrefPopulations } from '../types/prefPopulations'
 
 interface Props {
   choosePrefs: ChoosePrefs[]
   setChoosePrefs: Dispatch<SetStateAction<ChoosePrefs[]>>
   prefPopulations: PrefPopulations[]
   setPrefPopulations: Dispatch<SetStateAction<PrefPopulations[]>>
-}
-// let aaa = [
-//   [
-//     data: [
-//       [year: 1960, value: 10000],
-//       [year: 1345, value: 10000]
-//     ],
-//     prefName: "東京"
-//   ],
-//   [
-//     data: [
-//       [year: 1960, value: 10000],
-//       [year: 1345, value: 10000]
-//     ],
-//     prefName: "東京"
-//   ]
-// ]
-
-interface NewPrefData {
-  data: Prefdata
-  prefName: string
 }
 
 export const PrefectureList: FC<Props> = ({
@@ -62,18 +41,11 @@ export const PrefectureList: FC<Props> = ({
     )
       .then((res) => res.json())
       .then((res) => {
-        // setPrefPopulations([...prefPopulations, res.result.data[0].data])
         setPrefPopulations([
           ...prefPopulations,
           { data: res.result.data[0].data, prefName: prefName },
         ])
-        // let newData: PrefPopulations[] = [
-        //   { data: res.result.data[0].data },
-        //   { prefName: prefName },
-        // ]
-        // setPrefPopulations([...prefPopulations, newData])
       })
-    console.log(prefPopulations)
   }
 
   // 指定された都道府県のデータを削除

--- a/src/components/PrefectureList.tsx
+++ b/src/components/PrefectureList.tsx
@@ -1,15 +1,34 @@
 import { Dispatch, FC, SetStateAction, useEffect, useState, VFC } from 'react'
 import { ChoosePrefs } from '../types/choosePrefs'
 import { Prefectures } from '../types/prefectures'
-import { PrefPopulations } from '../types/prefPopulations'
+import { Prefdata, PrefPopulations } from '../types/prefPopulations'
 
 interface Props {
-  // choosePrefs: string[]
-  // setChoosePrefs: Dispatch<SetStateAction<string[]>>
   choosePrefs: ChoosePrefs[]
   setChoosePrefs: Dispatch<SetStateAction<ChoosePrefs[]>>
   prefPopulations: PrefPopulations[]
   setPrefPopulations: Dispatch<SetStateAction<PrefPopulations[]>>
+}
+// let aaa = [
+//   [
+//     data: [
+//       [year: 1960, value: 10000],
+//       [year: 1345, value: 10000]
+//     ],
+//     prefName: "東京"
+//   ],
+//   [
+//     data: [
+//       [year: 1960, value: 10000],
+//       [year: 1345, value: 10000]
+//     ],
+//     prefName: "東京"
+//   ]
+// ]
+
+interface NewPrefData {
+  data: Prefdata
+  prefName: string
 }
 
 export const PrefectureList: FC<Props> = ({
@@ -32,7 +51,7 @@ export const PrefectureList: FC<Props> = ({
   }, [])
 
   // 都道府県のデータを取得
-  const addPrefData = (prefCode: string) => {
+  const addPrefData = (prefCode: string, prefName: string) => {
     fetch(
       `https://opendata.resas-portal.go.jp/api/v1/population/composition/perYear?cityCode=-&prefCode=${prefCode}`,
       {
@@ -43,8 +62,18 @@ export const PrefectureList: FC<Props> = ({
     )
       .then((res) => res.json())
       .then((res) => {
-        setPrefPopulations([...prefPopulations, res.result.data[0].data])
+        // setPrefPopulations([...prefPopulations, res.result.data[0].data])
+        setPrefPopulations([
+          ...prefPopulations,
+          { data: res.result.data[0].data, prefName: prefName },
+        ])
+        // let newData: PrefPopulations[] = [
+        //   { data: res.result.data[0].data },
+        //   { prefName: prefName },
+        // ]
+        // setPrefPopulations([...prefPopulations, newData])
       })
+    console.log(prefPopulations)
   }
 
   // 指定された都道府県のデータを削除
@@ -72,7 +101,7 @@ export const PrefectureList: FC<Props> = ({
         ...choosePrefs,
         { prefCode: prefCode, prefName: prefName },
       ])
-      addPrefData(prefCode)
+      addPrefData(prefCode, prefName)
     }
   }
 

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,12 +1,13 @@
 import type { NextPage } from 'next'
-import React, { useState, useEffect, useCallback } from 'react'
+import React, { useState } from 'react'
 import Head from 'next/head'
 import { PrefectureList } from '../components/PrefectureList'
 import { PrefPopulations } from '../types/prefPopulations'
 import { Chart } from '../components/Chart'
+import { ChoosePrefs } from '../types/choosePrefs'
 
 const Home: NextPage = () => {
-  const [choosePref, setChoosePref] = useState<string[]>([])
+  const [choosePrefs, setChoosePrefs] = useState<ChoosePrefs[]>([])
   const [prefPopulations, setPrefPopulations] = useState<PrefPopulations[]>([])
 
   return (
@@ -20,8 +21,8 @@ const Home: NextPage = () => {
 
       <main>
         <PrefectureList
-          choosePref={choosePref}
-          setChoosePref={setChoosePref}
+          choosePrefs={choosePrefs}
+          setChoosePrefs={setChoosePrefs}
           prefPopulations={prefPopulations}
           setPrefPopulations={setPrefPopulations}
         />

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -2,12 +2,12 @@ import type { NextPage } from 'next'
 import React, { useState, useEffect, useCallback } from 'react'
 import Head from 'next/head'
 import { PrefectureList } from '../components/PrefectureList'
-import { PrefPopulation } from '../types/prefPopulation'
+import { PrefPopulations } from '../types/prefPopulations'
 import { Chart } from '../components/Chart'
 
 const Home: NextPage = () => {
   const [choosePref, setChoosePref] = useState<string[]>([])
-  const [prefPopulation, setPrefPopulation] = useState<PrefPopulation[]>([])
+  const [prefPopulations, setPrefPopulations] = useState<PrefPopulations[]>([])
 
   return (
     <div>
@@ -22,11 +22,11 @@ const Home: NextPage = () => {
         <PrefectureList
           choosePref={choosePref}
           setChoosePref={setChoosePref}
-          prefPopulation={prefPopulation}
-          setPrefPopulation={setPrefPopulation}
+          prefPopulations={prefPopulations}
+          setPrefPopulations={setPrefPopulations}
         />
 
-        <Chart prefPopulation={prefPopulation} />
+        <Chart prefPopulations={prefPopulations} />
       </main>
       <footer></footer>
     </div>

--- a/src/types/choosePrefs.ts
+++ b/src/types/choosePrefs.ts
@@ -1,0 +1,4 @@
+export interface ChoosePrefs {
+  prefCode: string
+  prefName: string
+}

--- a/src/types/prefPopulation.ts
+++ b/src/types/prefPopulation.ts
@@ -1,4 +1,0 @@
-export interface PrefPopulation {
-  year: number
-  value: number
-}

--- a/src/types/prefPopulations.ts
+++ b/src/types/prefPopulations.ts
@@ -4,6 +4,6 @@ export interface Prefdata {
 }
 
 export interface PrefPopulations {
-  data: Prefdata
+  data: Prefdata[]
   prefName: string
 }

--- a/src/types/prefPopulations.ts
+++ b/src/types/prefPopulations.ts
@@ -1,0 +1,4 @@
+export interface PrefPopulations {
+  year: number
+  value: number
+}

--- a/src/types/prefPopulations.ts
+++ b/src/types/prefPopulations.ts
@@ -1,4 +1,9 @@
-export interface PrefPopulations {
+export interface Prefdata {
   year: number
   value: number
+}
+
+export interface PrefPopulations {
+  data: Prefdata
+  prefName: string
 }

--- a/src/types/series..ts
+++ b/src/types/series..ts
@@ -1,0 +1,5 @@
+export interface Series {
+  name: string
+  data: number[]
+  pointPlacement: string
+}


### PR DESCRIPTION
## 概要
グラフのnameに都道府県名を設定
## 詳細
- prefPopulationsに、year, valueだけでなく、その都道府県名も追加した
- 不要なコード、コメントを削除

![スクリーンショット 2022-04-17 221643](https://user-images.githubusercontent.com/88410576/163716020-9925a03a-3348-4c70-91b1-be416ecb31a8.png)
。