### PR TITLE
exlintを直す

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,12 +1,11 @@
 {
-  "plugins": ["prettier", "unused-imports", "react-hooks"],
+  "plugins": ["prettier", "unused-imports"],
   "extends": [
     "next",
     "next/core-web-vitals",
     "plugin:import/recommended",
     "plugin:import/typescript",
     "plugin:import/warnings",
-    "plugin:react-hooks/recommended",
     "prettier"
   ],
 

--- a/src/components/Chart.tsx
+++ b/src/components/Chart.tsx
@@ -1,8 +1,8 @@
+import Highcharts from 'highcharts'
+import HighchartsReact from 'highcharts-react-official'
+import HighchartsExporting from 'highcharts/modules/exporting'
 import { FC } from 'react'
 import { PrefPopulations } from '../types/prefPopulations'
-import Highcharts from 'highcharts'
-import HighchartsExporting from 'highcharts/modules/exporting'
-import HighchartsReact from 'highcharts-react-official'
 import { Series } from '../types/series.'
 
 interface Props {

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -1,5 +1,5 @@
 import Head from 'next/head'
-import { FC, ReactNode } from 'react'
+import { ReactNode, FC } from 'react'
 
 interface Props {
   children: ReactNode

--- a/src/components/PrefectureList.tsx
+++ b/src/components/PrefectureList.tsx
@@ -6,8 +6,8 @@ import {
   useEffect,
   useState,
 } from 'react'
-import { Prefectures } from '../types/prefectures'
 import { PrefPopulations } from '../types/prefPopulations'
+import { Prefectures } from '../types/prefectures'
 
 interface Props {
   prefPopulations: PrefPopulations[]

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,10 +1,9 @@
 import type { NextPage } from 'next'
 import React, { useState } from 'react'
-import Head from 'next/head'
-import { PrefectureList } from '../components/PrefectureList'
-import { PrefPopulations } from '../types/prefPopulations'
 import { Chart } from '../components/Chart'
 import { Layout } from '../components/Layout'
+import { PrefectureList } from '../components/PrefectureList'
+import { PrefPopulations } from '../types/prefPopulations'
 
 const Home: NextPage = () => {
   const [prefPopulations, setPrefPopulations] = useState<PrefPopulations[]>([])


### PR DESCRIPTION
## 概要
eslint を修正
## 詳細
eslint.jsonのplugin, extendのreact-hooksを消したら、eslintが効くようになった。